### PR TITLE
Add missing pip install for handyspark (google colab)

### DIFF
--- a/notebooks/Exploring_Titanic.ipynb
+++ b/notebooks/Exploring_Titanic.ipynb
@@ -22,7 +22,7 @@
     "#!tar xf spark-2.3.1-bin-hadoop2.7.tgz\n",
     "#!pip install -q pyspark==2.3.1\n",
     "#!pip install -q findspark\n",
-    "#!pip install -q findspark\n",
+    "#!pip install -q handyspark\n",
     "\n",
     "#import os\n",
     "#os.environ[\"JAVA_HOME\"] = \"/usr/lib/jvm/java-8-openjdk-amd64\"\n",


### PR DESCRIPTION
Fix missing handyspark package error. two cells below, when using Google colab.